### PR TITLE
Added Trim

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ module.exports = function (pem) {
     if (!m) return undefined;
     var type = m[1].toLowerCase();
     
-    if (pem.split('\n').slice(-2)[0] !== '-----END RSA ' + m[1] + ' KEY-----') {
+    if ((pem.split('\n').slice(-2)[0]).trim() !== '-----END RSA ' + m[1] + ' KEY-----') {
         return undefined;
     }
     


### PR DESCRIPTION
Trim has been added because the condition was returning undefined

` if ((pem.split('\n').slice(-2)[0]) !== '-----END RSA ' + m[1] + ' KEY-----') {
        return undefined;
    }`

Getting true on valid pem key